### PR TITLE
Fix "withNetworkConnectionConfig".

### DIFF
--- a/src/Rest/MobileIdRestConnector.php
+++ b/src/Rest/MobileIdRestConnector.php
@@ -175,6 +175,12 @@ class MobileIdRestConnector implements MobileIdConnector
         curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "POST");
         curl_setopt($ch, CURLOPT_POSTFIELDS, $json);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+
+        if ( isset( $this->clientConfig ) && !empty( $this->clientConfig ) )
+        {
+            curl_setopt( $ch, CURLOPT_INTERFACE, $this->clientConfig );
+        }
+
         curl_setopt($ch, CURLOPT_HTTPHEADER, array(
                 'Content-Type: application/json',
                 'Content-Length: ' . strlen($json))
@@ -213,6 +219,12 @@ class MobileIdRestConnector implements MobileIdConnector
         $ch = curl_init($url);
         curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "GET");
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+
+        if ( isset( $this->clientConfig ) && !empty( $this->clientConfig ) )
+        {
+            curl_setopt( $ch, CURLOPT_INTERFACE, $this->clientConfig );
+        }
+
         curl_setopt($ch, CURLOPT_HTTPHEADER,
             array('Content-Type: application/json')
         );


### PR DESCRIPTION
Allows selecting network inteface / public IP when server has multiple network cards or multiple IPs.
Usage (use your real public IP) : MobileIdClient::newBuilder()->withNetworkConnectionConfig('111.222.23.23').

This is important because some servers have multiple public IP's and only one of them might be allowed to make requests to Mobile-ID REST API.

Smart-ID PHP library already had "->withNetworkInterface(OUR_PUBLIC_IP)", but Mobile-ID library similar version method "->withNetworkConnectionConfig(OUR_PUBLIC_IP)" seemed to do NOTHING currently. It does set the clientConfig property but nothing actually used it. I added a simple implementation to use it as our interface to enable similar usage as in Smart-ID library. 