### PR TITLE
throw MidInternalErrorException on invalid json result

### DIFF
--- a/src/Rest/MobileIdRestConnector.php
+++ b/src/Rest/MobileIdRestConnector.php
@@ -213,7 +213,6 @@ class MobileIdRestConnector implements MobileIdConnector
 
     private function getRequest(string $url) : array
     {
-
         $ch = curl_init($url);
         curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "GET");
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
@@ -223,6 +222,10 @@ class MobileIdRestConnector implements MobileIdConnector
         $result = curl_exec($ch);
 
         $this->logger->debug('Result is '. $result);
+
+        if (is_null($result)) {
+            throw new MidInternalErrorException('GET request to MID returned invalid json: ' . json_last_error_msg());
+        }
 
         return json_decode($result, true);
     }

--- a/src/Rest/MobileIdRestConnector.php
+++ b/src/Rest/MobileIdRestConnector.php
@@ -223,11 +223,13 @@ class MobileIdRestConnector implements MobileIdConnector
 
         $this->logger->debug('Result is '. $result);
 
-        if (is_null($result)) {
+        $responseAsArray = json_decode($result, true);
+
+        if (is_null($responseAsArray)) {
             throw new MidInternalErrorException('GET request to MID returned invalid json: ' . json_last_error_msg());
         }
 
-        return json_decode($result, true);
+        return $responseAsArray;
     }
 
     private function addCustomHeaders(array $headers){


### PR DESCRIPTION
Fixes situation where json parse failed and PHP throws TypeError

```
Exception "TypeError": Return value of Sk\Mid\Rest\MobileIdRestConnector::getRequest() must be of the type array, null returned on vendor/sk-id-solutions/mobile-id-php-client/src/Rest/MobileIdRestConnector.php(223)
```