### PR TITLE
Fix string concatenation operator to avoid warnings.

### DIFF
--- a/src/Rest/MobileIdRestConnector.php
+++ b/src/Rest/MobileIdRestConnector.php
@@ -173,7 +173,7 @@ class MobileIdRestConnector implements MobileIdConnector
                 $this->logger->error("MID returned error code '" . $result . "'");
                 throw new MidInternalErrorException("MID returned error code '" . $result . "'");
         }
-        
+
     }
 
     private function postAuthenticationRequest(string $uri, AuthenticationRequest $request) : AuthenticationResponse
@@ -268,7 +268,7 @@ class MobileIdRestConnector implements MobileIdConnector
         {
             curl_setopt( $ch, CURLOPT_INTERFACE, $this->networkInterface );
 
-            $this->logger->debug("CURLOPT_INTERFACE set to:" + $this->networkInterface);
+            $this->logger->debug("CURLOPT_INTERFACE set to:" . $this->networkInterface);
         }
 
         curl_setopt($ch, CURLOPT_HTTPHEADER,


### PR DESCRIPTION
Probably an honest typo but causes a nasty PHP warning when ->withNetworkInterface("10.11.12.13") is used.